### PR TITLE
fix: Uncaught ReferenceError: timer is not defined at chplayer.judgeI…

### DIFF
--- a/chplayer/chplayer.js
+++ b/chplayer/chplayer.js
@@ -3316,7 +3316,7 @@
 						thisTemp.CB['timeText'].innerHTML = thisTemp.getNowDate();
 					}
 				};
-				this.timerTime = new timer(1000, timeFun);
+				this.timerTime = new this.timer(1000, timeFun);
 				//timerTime.start();
 			}
 			this.definition();


### PR DESCRIPTION
Fixes #7 
timer was defined at chplayer.js:5422
```
timer: function(time, fun, number) {
……
}
```